### PR TITLE
Added alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,10 @@
   },
   "autoload": {
     "psr-0": { "ILess": "lib/" }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.6-dev"
+    }
   }
 }


### PR DESCRIPTION
Partially fixes #9. This library is very stable and consistent in master branch, so you should create a tag. I prefer syncing the release number with less.js.
