### PR TITLE
Implement function 'replace'

### DIFF
--- a/lib/ILess/FunctionRegistry.php
+++ b/lib/ILess/FunctionRegistry.php
@@ -108,6 +108,7 @@ class ILess_FunctionRegistry
         'pi' => true,
         'pow' => true,
         'red' => true,
+        'replace' => true,
         'rgb' => true,
         'rgba' => true,
         'round' => true,
@@ -402,6 +403,26 @@ class ILess_FunctionRegistry
             }
         }
         $string = str_replace('%%', '%', $string);
+
+        return new ILess_Node_Quoted('"' . $string . '"', $string);
+    }
+
+    /**
+     * Replaces a string or regexp pattern within a string.
+     *
+     * @param object $string
+     * @param object $pattern
+     * @param object $replacement
+     * @param $flags
+     * @return ILess_Node_Quoted
+     */
+    public function replace(ILess_Node $string, ILess_Node $pattern, ILess_Node $replacement, ILess_Node $flags = null)
+    {
+        $flags  = $flags ? $flags->value : '';
+        $limit = strpos($flags, 'g') === false ? 1 : -1;
+        $flags = str_replace('g', '', $flags);
+
+        $string = preg_replace('/' . $pattern->value . '/' . $flags, $replacement->value, $string->value);
 
         return new ILess_Node_Quoted('"' . $string . '"', $string);
     }

--- a/tests/ILess/Test/FunctionRegistryTest.php
+++ b/tests/ILess/Test/FunctionRegistryTest.php
@@ -140,7 +140,7 @@ class ILess_Test_FunctionRegistryTest extends ILess_Test_TestCase
         $this->assertInstanceOf('ILess_Node_Quoted', $result);
         $this->assertEquals($expected, $result->value);
     }
-
+    
     public function getDataForTemplateTest()
     {
         return array(
@@ -152,6 +152,51 @@ class ILess_Test_FunctionRegistryTest extends ILess_Test_TestCase
                 ),
                 'repetitions: 3 file: "directory/file.less"'
             ));
+    }
+
+    /**
+     * @covers       ILess_Function::replace
+     * @dataProvider getDataForReplaceTest
+     */
+    public function testReplace($string, $pattern, $replacement, $flags, $expected)
+    {
+        $result = $this->registry->replace($string, $pattern, $replacement, $flags, $expected);
+        
+        $this->assertEquals($result, $expected);
+    }
+
+    public function getDataForReplaceTest()
+    {
+        return array(
+            array(
+                new ILess_Node_Anonymous('Hello, Mars?'),
+                new ILess_Node_Anonymous('Mars\?'),
+                new ILess_Node_Anonymous('Earth!'),
+                null,
+                new ILess_Node_Quoted('"Hello, Earth!"', 'Hello, Earth!')
+            ),
+            array(
+                new ILess_Node_Anonymous('One + one = 4'),
+                new ILess_Node_Anonymous('one'),
+                new ILess_Node_Anonymous('2'),
+                new ILess_Node_Anonymous('gi'),
+                new ILess_Node_Quoted('"2 + 2 = 4"', '2 + 2 = 4')
+            ),
+            array(
+                new ILess_Node_Anonymous('This is a string.'),
+                new ILess_Node_Anonymous('(string)\.$'),
+                new ILess_Node_Anonymous('new $1.'),
+                null,
+                new ILess_Node_Quoted('"This is a new string."', 'This is a new string.')
+            ),
+            array(
+                new ILess_Node_Anonymous('bar-1'),
+                new ILess_Node_Anonymous('1'),
+                new ILess_Node_Anonymous('2'),
+                null,
+                new ILess_Node_Quoted('"bar-2"', 'bar-2')
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
We are using your compiler in the open source project [Stud.IP](http://develop.studip.de) and noticed that your library is missing the LESS string function [replace](http://lesscss.org/functions/#string-functions-replace).

I used the examples from the LESS page to set up the test cases and since it all seems to work fine, I thought I could help making your library more compatible to LESS v1.7.
