### PR TITLE
Fixed precision error on my machine on last digit via using regexps

### DIFF
--- a/tests/ILess/Test/Parser/ParsingTest.php
+++ b/tests/ILess/Test/Parser/ParsingTest.php
@@ -60,7 +60,19 @@ class ILess_Test_Parser_ParsingTest extends ILess_Test_TestCase
         if (is_readable($diffFile = str_replace('/less/', '/diff/', $lessFile . '.php'))) {
             $diff = include $diffFile;
             $actualDiff = array_diff(explode("\n", $compiled), explode("\n", $preCompiled));
-            $this->assertEquals($diff, $actualDiff);
+            foreach ($diff as $lineNum => $change) {
+                if ($change[0] == '#') {
+                    if (preg_match($change, @$actualDiff[$lineNum])) {
+                        unset($actualDiff[$lineNum]);
+                    }
+                } else
+                {
+                    if (@$actualDiff[$lineNum] == $change) {
+                        unset($actualDiff[$lineNum]);
+                    }
+                }
+            }
+            $this->assertEquals($actualDiff, array());
         } else {
             $this->assertEquals($preCompiled, $compiled);
         }

--- a/tests/ILess/Test/Parser/_fixtures/less.js/diff/functions.less.php
+++ b/tests/ILess/Test/Parser/_fixtures/less.js/diff/functions.less.php
@@ -2,7 +2,7 @@
 
 // a list of known and "tolerated" differences
 return array(
-     74 => '  tan: 0.9004040442978022;', // less.js:   tan: 0.9004040442978399;
+     74 => '#  tan: 0\.900404044297802\d;#', // less.js:   tan: 0.9004040442978399;
      75 => '  sin: 0.1736481776669255;', // less.js:   sin: 0.17364817766693033;
      77 => '  atan: 0.09999999999999995rad;', // less.js:   atan: 0.1rad;
      78 => '  atan: 33.9999999999999842deg;', // less.js:   atan: 34.00000000000001deg;


### PR DESCRIPTION
On my mac a test failed due to precision differences (64 bit? Library difference? Really I don't know). So I had to change how the tolerances worked to make this pass in a clean way.